### PR TITLE
Use existing title class

### DIFF
--- a/src/plugins/embeddable/public/lib/panel/_embeddable_panel.scss
+++ b/src/plugins/embeddable/public/lib/panel/_embeddable_panel.scss
@@ -64,16 +64,12 @@
 
   .embPanel__titleText {
     @include euiTextTruncate;
-  }
-
-  .embPanel__titleLink {
     font-weight: $euiFontWeightBold;
   }
 
   .embPanel__placeholderTitleText {
-    @include euiTextTruncate;
-    font-weight: $euiFontWeightRegular;
     color: $euiColorMediumShade;
+    font-weight: $euiFontWeightRegular;
   }
 }
 

--- a/src/plugins/embeddable/public/lib/panel/panel_header/panel_header.tsx
+++ b/src/plugins/embeddable/public/lib/panel/panel_header/panel_header.tsx
@@ -179,16 +179,22 @@ export function PanelHeader({
     let titleComponent;
     if (showTitle) {
       titleComponent = isViewMode ? (
-        <span className={title ? 'embPanel__titleText' : 'embPanel__placeholderTitleText'}>
+        <span
+          className={classNames('embPanel__titleText', {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            embPanel__placeholderTitleText: !title,
+          })}
+        >
           {title || placeholderTitle}
         </span>
       ) : (
         <EuiLink
           color="text"
           data-test-subj={'embeddablePanelTitleLink'}
-          className={
-            title ? 'embPanel__titleText embPanel__titleLink' : 'embPanel__placeholderTitleText'
-          }
+          className={classNames('embPanel__titleText', {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            embPanel__placeholderTitleText: !title,
+          })}
           aria-label={i18n.translate('embeddableApi.panel.editTitleAriaLabel', {
             defaultMessage: 'Click to edit title: {title}',
             values: { title: title || placeholderTitle },


### PR DESCRIPTION
In reviewing this, it struck me that we could probably get by using the existing classes and not introduce another one (as I suggested prior). To that point, I changed the `className` logic slightly to go this route.

If nothing else, the css feels a bit more readable... all titles are titles, but if its a placeholder then tone down the color and weight. This way, going forward, any further title changes will be shared at the root and not have to be applied to both the title and placeholder separately :) 
