### PR TITLE
Adjust types

### DIFF
--- a/x-pack/plugins/lens/server/embeddable/lens_embeddable_factory.ts
+++ b/x-pack/plugins/lens/server/embeddable/lens_embeddable_factory.ts
@@ -16,10 +16,14 @@ export const lensEmbeddableFactory = (): EmbeddableRegistryDefinition => {
     id: DOC_TYPE,
     migrations: {
       // This migration is run in 7.13.1 for `by value` panels because the 7.13 release window was missed.
-      '7.13.1': (state) =>
-        (commonRenameOperationsForFormula(
-          (state as unknown) as { attributes: LensDocShapePre712 }
-        ) as unknown) as SerializableState,
+      '7.13.1': (state) => {
+        const lensState = (state as unknown) as { attributes: LensDocShapePre712 };
+        const migratedLensState = commonRenameOperationsForFormula(lensState.attributes);
+        return ({
+          ...lensState,
+          attributes: migratedLensState,
+        } as unknown) as SerializableState;
+      },
     },
   };
 };

--- a/x-pack/plugins/lens/server/migrations/common_migrations.ts
+++ b/x-pack/plugins/lens/server/migrations/common_migrations.ts
@@ -6,12 +6,11 @@
  */
 
 import { cloneDeep } from 'lodash';
-import { SavedObjectUnsanitizedDoc } from '../../../../../src/core/server';
 import { LensDocShapePre712, OperationTypePre712, LensDocShapePost712 } from './types';
 
-export const commonRenameOperationsForFormula = (doc: {
-  attributes: LensDocShapePre712;
-}): { attributes: LensDocShapePost712 } => {
+export const commonRenameOperationsForFormula = (
+  attributes: LensDocShapePre712
+): LensDocShapePost712 => {
   const renameMapping = {
     avg: 'average',
     cardinality: 'unique_count',
@@ -20,9 +19,9 @@ export const commonRenameOperationsForFormula = (doc: {
   function shouldBeRenamed(op: OperationTypePre712): op is keyof typeof renameMapping {
     return op in renameMapping;
   }
-  const newDoc = cloneDeep(doc);
-  const datasourceLayers = newDoc.attributes.state.datasourceStates.indexpattern.layers || {};
-  (newDoc.attributes as LensDocShapePost712).state.datasourceStates.indexpattern.layers = Object.fromEntries(
+  const newAttributes = cloneDeep(attributes);
+  const datasourceLayers = newAttributes.state.datasourceStates.indexpattern.layers || {};
+  (newAttributes as LensDocShapePost712).state.datasourceStates.indexpattern.layers = Object.fromEntries(
     Object.entries(datasourceLayers).map(([layerId, layer]) => {
       return [
         layerId,
@@ -43,5 +42,5 @@ export const commonRenameOperationsForFormula = (doc: {
       ];
     })
   );
-  return newDoc as SavedObjectUnsanitizedDoc<LensDocShapePost712>;
+  return newAttributes as LensDocShapePost712;
 };

--- a/x-pack/plugins/lens/server/migrations/saved_object_migrations.ts
+++ b/x-pack/plugins/lens/server/migrations/saved_object_migrations.ts
@@ -393,7 +393,11 @@ const renameOperationsForFormula: SavedObjectMigrationFn<
   LensDocShapePre712,
   LensDocShapePost712
 > = (doc) => {
-  return commonRenameOperationsForFormula(doc) as SavedObjectUnsanitizedDoc<LensDocShapePost712>;
+  const newDoc = cloneDeep(doc);
+  return {
+    ...newDoc,
+    attributes: commonRenameOperationsForFormula(newDoc.attributes),
+  };
 };
 
 export const migrations: SavedObjectMigrationMap = {


### PR DESCRIPTION
I'm a bit concerned about `commonRenameOperationsForFormula` being responsible to clone a full document, but being typed as only `{ attributes: LensDocShapePre712 }` (especially for the next instance where we have to do the same thing of splitting out the actual migration to work for both cases).

This PR refactors the code a bit so `commonRenameOperationsForFormula` only handles the attributes, and the embeddable migration / SO migration handles the respective wrapper objects