### PR TITLE
Design comments for initial OptionsList

### DIFF
--- a/src/plugins/presentation_util/public/components/input_controls/options_list/options_list_control.scss
+++ b/src/plugins/presentation_util/public/components/input_controls/options_list/options_list_control.scss
@@ -7,6 +7,19 @@
 }
 
 .optionsList--buttonOverride {
+  &:hover:not(:disabled),
+  &:focus:not(:disabled) {
+    // Remove underline from whole button so notifications don't get the underline
+    text-decoration: none;
+  
+    .optionsList--title {
+      // Add put it only on the actual text part
+      text-decoration: underline;
+    }
+  }
+}
+
+.optionsList--buttonOverrideTwoLine {
   height: auto !important;
   width: 100%;
 
@@ -19,16 +32,6 @@
     }
   }
 
-  &:hover:not(:disabled),
-  &:focus:not(:disabled) {
-    // Remove underline from whole button so notifications don't get the underline
-    text-decoration: none;
-
-    .optionsList--title {
-      // Add put it only on the actual text part
-      text-decoration: underline;
-    }
-  }
 }
 
 .optionsList--items {
@@ -42,22 +45,15 @@
 
 .optionsList {
   background-color: $euiFormBackgroundColor;
-  // border: 1px solid $euiFormBorderColor;
-  // border-radius: $euiBorderRadius;
-  // display: flex;
-  // align-items: stretch;
-  // font-size: $euiFontSizeS;
   width: 100%;
   height: 100%;
 
   &.optionsList--twoLine {
-    // background-color: $euiFormBackgroundColor;
     border: 1px solid $euiFormBorderColor;
     border-radius: $euiBorderRadius;
     display: flex;
     align-items: stretch;
     font-size: $euiFontSizeS;
-    // width: 100%;
     flex-direction: column;
 
     .optionsList--control {
@@ -71,15 +67,13 @@
     padding: $euiSizeXS $euiSizeS;
     display: flex;
     align-items: center;
-    font-weight: $euiFontWeightBold;
   }
 
   .optionsList--control {
     flex-grow: 1;
     display: flex;
-    // flex-direction: row;
-    // height: $euiFormControlHeight;
     align-items: center;
+    height: 100%;
 
     .optionsList--selections {
       flex: 1;
@@ -111,6 +105,14 @@
   height: 100%;
 }
 
-.tempButton {
+.optionsList--buttonOverrideSingle {
+  height: 100%;
   width: 100%;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  overflow: hidden;
+}
+
+.optionsList--search {
+  padding: $euiSizeS;
 }

--- a/src/plugins/presentation_util/public/components/input_controls/options_list/options_list_control.scss
+++ b/src/plugins/presentation_util/public/components/input_controls/options_list/options_list_control.scss
@@ -40,18 +40,31 @@
   max-width: 100%;
 }
 
-.optionsList--twoLine {
-  flex-direction: column;
-}
-
 .optionsList {
   background-color: $euiFormBackgroundColor;
-  border: 1px solid $euiFormBorderColor;
-  border-radius: $euiBorderRadius;
-  display: flex;
-  align-items: stretch;
-  font-size: $euiFontSizeS;
+  // border: 1px solid $euiFormBorderColor;
+  // border-radius: $euiBorderRadius;
+  // display: flex;
+  // align-items: stretch;
+  // font-size: $euiFontSizeS;
   width: 100%;
+  height: 100%;
+
+  &.optionsList--twoLine {
+    // background-color: $euiFormBackgroundColor;
+    border: 1px solid $euiFormBorderColor;
+    border-radius: $euiBorderRadius;
+    display: flex;
+    align-items: stretch;
+    font-size: $euiFontSizeS;
+    // width: 100%;
+    flex-direction: column;
+
+    .optionsList--control {
+      height: $euiFormControlHeight;
+      flex-direction: row;
+    }
+  }
 
   .optionsList--title {
     background-color: $euiFormBorderColor;
@@ -64,8 +77,8 @@
   .optionsList--control {
     flex-grow: 1;
     display: flex;
-    flex-direction: row;
-    height: $euiFormControlHeight;
+    // flex-direction: row;
+    // height: $euiFormControlHeight;
     align-items: center;
 
     .optionsList--selections {
@@ -87,4 +100,17 @@
       padding: $euiSizeXS;
     }
   }
+}
+
+.optionsList--formControlLayout {
+  max-width: unset;
+}
+
+.optionsList--popoverOverride {
+  width: 100%;
+  height: 100%;
+}
+
+.tempButton {
+  width: 100%;
 }

--- a/src/plugins/presentation_util/public/components/input_controls/options_list/options_list_control.tsx
+++ b/src/plugins/presentation_util/public/components/input_controls/options_list/options_list_control.tsx
@@ -47,8 +47,9 @@ export const OptionsListControl = ({ twoLine, title, options }: OptionsListContr
   const button = (
     <EuiButtonEmpty
       color="text"
-      className={classNames('tempButton', {
-        'optionsList--buttonOverride': twoLine,
+      className={classNames('optionsList--buttonOverride', {
+        'optionsList--buttonOverrideTwoLine': twoLine,
+        'optionsList--buttonOverrideSingle': !twoLine,
       })}
       textProps={{
         className: classNames('optionsList', {
@@ -83,8 +84,6 @@ export const OptionsListControl = ({ twoLine, title, options }: OptionsListContr
       </span>
     </EuiButtonEmpty>
   );
-
-  const tempButton = <EuiButtonEmpty className="tempButton">hello</EuiButtonEmpty>;
 
   return (
     <>

--- a/src/plugins/presentation_util/public/components/input_controls/options_list/options_list_control.tsx
+++ b/src/plugins/presentation_util/public/components/input_controls/options_list/options_list_control.tsx
@@ -99,9 +99,10 @@ export const OptionsListControl = ({ twoLine, title, options }: OptionsListContr
           ownFocus
           repositionOnScroll
         >
-          <EuiPopoverTitle paddingSize="s">
+          <EuiPopoverTitle paddingSize="s">{title}</EuiPopoverTitle>
+          <div className="optionsList--search">
             <EuiFieldSearch compressed />
-          </EuiPopoverTitle>
+          </div>
           <div className="optionsList--items">
             {selectableOptions.map((item, index) => (
               <EuiFilterSelectItem

--- a/src/plugins/presentation_util/public/components/input_controls/options_list/options_list_control.tsx
+++ b/src/plugins/presentation_util/public/components/input_controls/options_list/options_list_control.tsx
@@ -15,6 +15,7 @@ import {
   EuiFilterSelectItem,
   EuiPopoverTitle,
   EuiSelectableProps,
+  EuiFormControlLayout,
 } from '@elastic/eui';
 
 import classNames from 'classnames';
@@ -46,7 +47,9 @@ export const OptionsListControl = ({ twoLine, title, options }: OptionsListContr
   const button = (
     <EuiButtonEmpty
       color="text"
-      className="optionsList--buttonOverride"
+      className={classNames('tempButton', {
+        'optionsList--buttonOverride': twoLine,
+      })}
       textProps={{
         className: classNames('optionsList', {
           'optionsList--twoLine': twoLine,
@@ -55,7 +58,7 @@ export const OptionsListControl = ({ twoLine, title, options }: OptionsListContr
       onClick={() => setIsPopoverOpen((open) => !open)}
       contentProps={{ className: 'optionsList--buttonContentOverride' }}
     >
-      <span className="optionsList--title">{startCase(title)}</span>
+      {twoLine ? <span className="optionsList--title">{startCase(title)}</span> : null}
       <span className="optionsList--control">
         <span
           className={classNames('optionsList--selections', {
@@ -81,28 +84,73 @@ export const OptionsListControl = ({ twoLine, title, options }: OptionsListContr
     </EuiButtonEmpty>
   );
 
+  const tempButton = <EuiButtonEmpty className="tempButton">hello</EuiButtonEmpty>;
+
   return (
-    <EuiPopover
-      id="popoverExampleMultiSelect"
-      button={button}
-      isOpen={isPopoverOpen}
-      anchorClassName="optionsList--anchorOverride"
-      closePopover={() => setIsPopoverOpen(false)}
-      panelPaddingSize="none"
-      anchorPosition="upLeft"
-      ownFocus
-      repositionOnScroll
-    >
-      <EuiPopoverTitle paddingSize="s">
-        <EuiFieldSearch compressed />
-      </EuiPopoverTitle>
-      <div className="optionsList--items">
-        {selectableOptions.map((item, index) => (
-          <EuiFilterSelectItem checked={item.checked} key={index} onClick={() => updateItem(index)}>
-            {item.label}
-          </EuiFilterSelectItem>
-        ))}
-      </div>
-    </EuiPopover>
+    <>
+      {twoLine ? (
+        <EuiPopover
+          id="popoverExampleMultiSelect"
+          button={button}
+          isOpen={isPopoverOpen}
+          anchorClassName="optionsList--anchorOverride"
+          closePopover={() => setIsPopoverOpen(false)}
+          panelPaddingSize="none"
+          anchorPosition="upLeft"
+          ownFocus
+          repositionOnScroll
+        >
+          <EuiPopoverTitle paddingSize="s">
+            <EuiFieldSearch compressed />
+          </EuiPopoverTitle>
+          <div className="optionsList--items">
+            {selectableOptions.map((item, index) => (
+              <EuiFilterSelectItem
+                checked={item.checked}
+                key={index}
+                onClick={() => updateItem(index)}
+              >
+                {item.label}
+              </EuiFilterSelectItem>
+            ))}
+          </div>
+        </EuiPopover>
+      ) : (
+        <EuiFormControlLayout
+          className="optionsList--formControlLayout"
+          prepend={
+            <EuiButtonEmpty color="text" size="s" iconSide="right">
+              {startCase(title)}
+            </EuiButtonEmpty>
+          }
+        >
+          <EuiPopover
+            id="popoverExampleMultiSelect"
+            button={button}
+            className="optionsList--popoverOverride"
+            anchorClassName="optionsList--anchorOverride"
+            isOpen={isPopoverOpen}
+            closePopover={() => setIsPopoverOpen(false)}
+            panelPaddingSize="none"
+          >
+            <EuiPopoverTitle paddingSize="s">{title}</EuiPopoverTitle>
+            <div className="optionsList--search">
+              <EuiFieldSearch compressed />
+            </div>
+            <div className="optionsList--items">
+              {selectableOptions.map((item, index) => (
+                <EuiFilterSelectItem
+                  checked={item.checked}
+                  key={index}
+                  onClick={() => updateItem(index)}
+                >
+                  {item.label}
+                </EuiFilterSelectItem>
+              ))}
+            </div>
+          </EuiPopover>
+        </EuiFormControlLayout>
+      )}
+    </>
   );
 };


### PR DESCRIPTION
## Summary

Here are some thoughts I had while reviewing how this is currently setup and working on suggestions:

- We really need to consider whether we want to create a component from scratch. [**EuiFormControlLayout**](https://elastic.github.io/eui/#/forms/form-controls#form-control-layout) gets us fairly far but does not support the `twoLine` layout. If we really want to do the `twoLine` layout we could create a custom component for that and use **EuiFormControlLayout** for the single line layout. I can also check with Eui team to see if this is something they could add.  Eui has the strong advantage of already being optimized for colors, a11y, states (focus, hover, disabled) and K7+K8 support.

- In this PR, I'm using **EuiFormControlLayout** for the single line layout. I would like us to try using another option for displaying the list of options. Right now it is a **EuiButtonEmpty** + **EuiPopover** combo but I'm guessing using an input would be more appropriate. @ThomThomson I would need your support on that side.

- For the single line layout, I think we need to truncate the label in case it gets really long (this is the behaviour that **EuiFormControlLayou**t's `prepend` already includes). For that reason it'd be useful to include the full label in the popover.

<img width="492" alt="image 9" src="https://user-images.githubusercontent.com/4016496/125135288-977e2700-e0bd-11eb-9158-3917d7cae439.png">
<img width="700" alt="image 12" src="https://user-images.githubusercontent.com/4016496/125137643-f5147280-e0c1-11eb-8d3b-5abc498fd29c.png">

- Do we need the `label` to be clickable? Usually when the label (prepend) is clickable it is attached to a different action than the one on the right side. It feels a bit off to me when clicking anywhere on the element, triggers the same popover (i.e. left and right side have the same effect). Check out the use case below as an example where the left side button lets you choose between languages: Lucene, KQL, etc.

<img width="459" alt="Frame 2" src="https://user-images.githubusercontent.com/4016496/125136144-16279400-e0bf-11eb-9ecc-f41db2b533c9.png">

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
