### PR TITLE
[Controls] Add empty state and do cleanup

### DIFF
--- a/src/plugins/presentation_util/public/components/controls/__stories__/decorators.tsx
+++ b/src/plugins/presentation_util/public/components/controls/__stories__/decorators.tsx
@@ -23,12 +23,10 @@ const panelStyle = {
 
 const kqlBarStyle = { background: bar, padding: 16, minHeight, fontStyle: 'italic' };
 
-const inputBarStyle = { background: '#fff', padding: 4 };
-
 const layout = (OptionStory: Story) => (
   <EuiFlexGroup style={{ background }} direction="column">
     <EuiFlexItem style={kqlBarStyle}>KQL Bar</EuiFlexItem>
-    <EuiFlexItem style={inputBarStyle}>
+    <EuiFlexItem>
       <OptionStory />
     </EuiFlexItem>
     <EuiFlexItem>

--- a/src/plugins/presentation_util/public/components/controls/control_group/component/control_frame_component.tsx
+++ b/src/plugins/presentation_util/public/components/controls/control_group/component/control_frame_component.tsx
@@ -89,13 +89,13 @@ export const ControlFrame = ({ customPrepend, enableActions, embeddableId }: Con
 
   const form = (
     <EuiFormControlLayout
-      className={'controlFrame--formControlLayout'}
+      className={'controlFrame__formControlLayout'}
       fullWidth
       prepend={
         <>
           {customPrepend ?? null}
           {usingTwoLineLayout ? undefined : (
-            <EuiFormLabel className="controlFrame--formControlLayout__label" htmlFor={embeddableId}>
+            <EuiFormLabel className="controlFrame__formControlLayoutLabel" htmlFor={embeddableId}>
               {title}
             </EuiFormLabel>
           )}
@@ -103,7 +103,7 @@ export const ControlFrame = ({ customPrepend, enableActions, embeddableId }: Con
       }
     >
       <div
-        className={classNames('controlFrame--control', {
+        className={classNames('controlFrame__control', {
           'controlFrame--twoLine': controlStyle === 'twoLine',
           'controlFrame--oneLine': controlStyle === 'oneLine',
         })}

--- a/src/plugins/presentation_util/public/components/controls/control_group/component/control_group_component.tsx
+++ b/src/plugins/presentation_util/public/components/controls/control_group/component/control_group_component.tsx
@@ -8,7 +8,15 @@
 
 import '../control_group.scss';
 
-import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiToolTip } from '@elastic/eui';
+import {
+  EuiButton,
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiToolTip,
+  EuiPanel,
+  EuiText,
+} from '@elastic/eui';
 import React, { useMemo, useState } from 'react';
 import classNames from 'classnames';
 import {
@@ -57,7 +65,7 @@ export const ControlGroup = () => {
   const dispatch = useEmbeddableDispatch();
 
   // current state
-  const { panels } = useEmbeddableSelector((state) => state);
+  const { panels, controlStyle } = useEmbeddableSelector((state) => state);
 
   const idsInOrder = useMemo(
     () =>
@@ -71,10 +79,10 @@ export const ControlGroup = () => {
   );
 
   const [draggingId, setDraggingId] = useState<string | null>(null);
-  const draggingIndex = useMemo(
-    () => (draggingId ? idsInOrder.indexOf(draggingId) : -1),
-    [idsInOrder, draggingId]
-  );
+  const draggingIndex = useMemo(() => (draggingId ? idsInOrder.indexOf(draggingId) : -1), [
+    idsInOrder,
+    draggingId,
+  ]);
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -92,63 +100,94 @@ export const ControlGroup = () => {
     setDraggingId(null);
   };
 
+  const emptyState = !(idsInOrder && idsInOrder.length > 0);
+
   return (
-    <EuiFlexGroup wrap={false} direction="row" alignItems="center" className="superWrapper">
-      <EuiFlexItem>
-        <DndContext
-          onDragStart={({ active }) => setDraggingId(active.id)}
-          onDragEnd={onDragEnd}
-          onDragCancel={() => setDraggingId(null)}
-          sensors={sensors}
-          collisionDetection={closestCenter}
-          layoutMeasuring={{
-            strategy: LayoutMeasuringStrategy.Always,
-          }}
-        >
-          <SortableContext items={idsInOrder} strategy={rectSortingStrategy}>
-            <EuiFlexGroup
-              className={classNames('controlGroup', { 'controlGroup-isDragging': draggingId })}
-              alignItems="center"
-              gutterSize={'m'}
-              wrap={true}
+    <EuiPanel
+      borderRadius="m"
+      className={classNames('controlsWrapper', {
+        'controlsWrapper--empty': emptyState,
+        'controlsWrapper--twoLine': controlStyle === 'twoLine',
+      })}
+    >
+      {idsInOrder.length > 0 ? (
+        <EuiFlexGroup gutterSize="m" wrap={false} direction="row" alignItems="center">
+          <EuiFlexItem>
+            <DndContext
+              onDragStart={({ active }) => setDraggingId(active.id)}
+              onDragEnd={onDragEnd}
+              onDragCancel={() => setDraggingId(null)}
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              layoutMeasuring={{
+                strategy: LayoutMeasuringStrategy.Always,
+              }}
             >
-              {idsInOrder.map(
-                (controlId, index) =>
-                  panels[controlId] && (
-                    <SortableControl
-                      dragInfo={{ index, draggingIndex }}
-                      embeddableId={controlId}
-                      key={controlId}
-                    />
-                  )
-              )}
-            </EuiFlexGroup>
-          </SortableContext>
-          <DragOverlay>{draggingId ? <ControlClone draggingId={draggingId} /> : null}</DragOverlay>
-        </DndContext>
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <EuiFlexGroup alignItems="center" direction="row" gutterSize="xs">
-          <EuiFlexItem>
-            <EuiToolTip content={ControlGroupStrings.management.getManageButtonTitle()}>
-              <EuiButtonIcon
-                aria-label={ControlGroupStrings.management.getManageButtonTitle()}
-                iconType="gear"
-                color="text"
-                data-test-subj="inputControlsSortingButton"
-                onClick={() =>
-                  openFlyout(forwardAllContext(<EditControlGroup />, reduxContainerContext))
-                }
-              />
-            </EuiToolTip>
+              <SortableContext items={idsInOrder} strategy={rectSortingStrategy}>
+                <EuiFlexGroup
+                  className={classNames('controlGroup', { 'controlGroup-isDragging': draggingId })}
+                  alignItems="center"
+                  gutterSize={'m'}
+                  wrap={true}
+                >
+                  {idsInOrder.map(
+                    (controlId, index) =>
+                      panels[controlId] && (
+                        <SortableControl
+                          dragInfo={{ index, draggingIndex }}
+                          embeddableId={controlId}
+                          key={controlId}
+                        />
+                      )
+                  )}
+                </EuiFlexGroup>
+              </SortableContext>
+              <DragOverlay>
+                {draggingId ? <ControlClone draggingId={draggingId} /> : null}
+              </DragOverlay>
+            </DndContext>
           </EuiFlexItem>
-          <EuiFlexItem>
-            <EuiToolTip content={ControlGroupStrings.management.getAddControlTitle()}>
-              <CreateControlButton />
-            </EuiToolTip>
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup className="groupEditActions" gutterSize="xs">
+              <EuiFlexItem>
+                <EuiToolTip content={ControlGroupStrings.management.getManageButtonTitle()}>
+                  <EuiButtonIcon
+                    aria-label={ControlGroupStrings.management.getManageButtonTitle()}
+                    iconType="gear"
+                    color="subdued"
+                    data-test-subj="inputControlsSortingButton"
+                    onClick={() =>
+                      openFlyout(forwardAllContext(<EditControlGroup />, reduxContainerContext))
+                    }
+                  />
+                </EuiToolTip>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiToolTip content={ControlGroupStrings.management.getAddControlTitle()}>
+                  <CreateControlButton />
+                </EuiToolTip>
+              </EuiFlexItem>
+            </EuiFlexGroup>
           </EuiFlexItem>
         </EuiFlexGroup>
-      </EuiFlexItem>
-    </EuiFlexGroup>
+      ) : (
+        <>
+          <EuiFlexGroup alignItems="center" gutterSize="xs">
+            <EuiFlexItem grow={1}>
+              <EuiText className="emptyStateText eui-textCenter" size="s">
+                <p>Controls let you filter and interact with your dashboard data</p>
+              </EuiText>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <div className="addControlButton">
+                <EuiButton size="s" color="primary">
+                  Add control
+                </EuiButton>
+              </div>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </>
+      )}
+    </EuiPanel>
   );
 };

--- a/src/plugins/presentation_util/public/components/controls/control_group/component/control_group_sortable_item.tsx
+++ b/src/plugins/presentation_util/public/components/controls/control_group/component/control_group_sortable_item.tsx
@@ -32,11 +32,19 @@ export type SortableControlProps = ControlFrameProps & {
  */
 export const SortableControl = (frameProps: SortableControlProps) => {
   const { embeddableId } = frameProps;
-  const { over, listeners, isSorting, transform, transition, attributes, isDragging, setNodeRef } =
-    useSortable({
-      id: embeddableId,
-      animateLayoutChanges: () => true,
-    });
+  const {
+    over,
+    listeners,
+    isSorting,
+    transform,
+    transition,
+    attributes,
+    isDragging,
+    setNodeRef,
+  } = useSortable({
+    id: embeddableId,
+    animateLayoutChanges: () => true,
+  });
 
   frameProps.dragInfo = { ...frameProps.dragInfo, isOver: over?.id === embeddableId, isDragging };
 
@@ -74,13 +82,13 @@ const SortableControlInner = forwardRef<
   return (
     <EuiFlexItem
       grow={width === 'auto'}
-      className={classNames('controlFrame--wrapper', {
-        'controlFrame--wrapper-isDragging': isDragging,
-        'controlFrame--wrapper-small': width === 'small',
-        'controlFrame--wrapper-medium': width === 'medium',
-        'controlFrame--wrapper-large': width === 'large',
-        'controlFrame--wrapper-insertBefore': isOver && (index ?? -1) < (draggingIndex ?? -1),
-        'controlFrame--wrapper-insertAfter': isOver && (index ?? -1) > (draggingIndex ?? -1),
+      className={classNames('controlFrame__wrapper', {
+        'controlFrame__wrapper-isDragging': isDragging,
+        'controlFrame__wrapper--small': width === 'small',
+        'controlFrame__wrapper--medium': width === 'medium',
+        'controlFrame__wrapper--large': width === 'large',
+        'controlFrame__wrapper--insertBefore': isOver && (index ?? -1) < (draggingIndex ?? -1),
+        'controlFrame__wrapper--insertAfter': isOver && (index ?? -1) > (draggingIndex ?? -1),
       })}
       style={style}
     >
@@ -106,11 +114,11 @@ export const ControlClone = ({ draggingId }: { draggingId: string }) => {
   const title = panels[draggingId].explicitInput.title;
   return (
     <EuiFlexItem
-      className={classNames('controlFrame--cloneWrapper', {
-        'controlFrame--cloneWrapper-small': width === 'small',
-        'controlFrame--cloneWrapper-medium': width === 'medium',
-        'controlFrame--cloneWrapper-large': width === 'large',
-        'controlFrame--cloneWrapper-twoLine': controlStyle === 'twoLine',
+      className={classNames('controlFrame__cloneWrapper', {
+        'controlFrame__cloneWrapper--small': width === 'small',
+        'controlFrame__cloneWrapper--medium': width === 'medium',
+        'controlFrame__cloneWrapper--large': width === 'large',
+        'controlFrame__cloneWrapper--twoLine': controlStyle === 'twoLine',
       })}
     >
       {controlStyle === 'twoLine' ? <EuiFormLabel>{title}</EuiFormLabel> : undefined}

--- a/src/plugins/presentation_util/public/components/controls/control_group/control_group.scss
+++ b/src/plugins/presentation_util/public/components/controls/control_group/control_group.scss
@@ -1,35 +1,62 @@
 $smallControl: $euiSize * 14;
 $mediumControl: $euiSize * 25;
 $largeControl: $euiSize * 50;
-$controlMinWidth: $euiSize * 14;
+$controlMinWidth: $euiSize * 16;
 
 .controlGroup {
-  margin-left: $euiSizeXS;
   overflow-x: clip; // sometimes when using auto width, removing a control can cause a horizontal scrollbar to appear.
   min-height: $euiSize * 4;
-  padding: $euiSize 0;
 }
 
-.controlFrame--cloneWrapper {
+.controlsWrapper {
+  &--empty {
+    display: flex;
+    @include euiBreakpoint('m', 'l', 'xl') {
+      background: url(opt_a.svg);
+      background-position: left top;
+      background-repeat: no-repeat;
+      .addControlButton {
+        text-align: center;
+      }
+      .emptyStateText {
+        padding-left: $euiSize * 2;
+      }
+    }
+    @include euiBreakpoint('xs', 's') {
+      .addControlButton {
+        text-align: center;
+      }
+    }
+    padding-right: $euiSizeL;
+  }
+
+  &--twoLine {
+    .groupEditActions {
+      padding-top: $euiSize;
+    }
+  }
+}
+
+.controlFrame__cloneWrapper {
   width: max-content;
 
   .euiFormLabel {
     padding-bottom: $euiSizeXS;
   }
 
-  &-small {
+  &--small {
     width: $smallControl;
   }
 
-  &-medium {
+  &--medium {
     width: $mediumControl;
   }
 
-  &-large {
+  &--large {
     width: $largeControl;
   }
 
-  &-twoLine {
+  &--twoLine {
     margin-top: -$euiSize * 1.25;
   }
 
@@ -49,7 +76,7 @@ $controlMinWidth: $euiSize * 14;
     min-width: $controlMinWidth;
   }
 
-  .controlFrame--formControlLayout, .controlFrame--draggable {
+  .controlFrame__formControlLayout, .controlFrame--draggable {
     &-clone {
       box-shadow: 0 0 0 1px $euiShadowColor,
         0 1px 6px 0 $euiShadowColor;
@@ -62,28 +89,28 @@ $controlMinWidth: $euiSize * 14;
   }
 }
 
-.controlFrame--wrapper {
+.controlFrame__wrapper {
   flex-basis: auto;
   position: relative;
   display: block;
 
-  .controlFrame--formControlLayout {
+  .controlFrame__formControlLayout {
     width: 100%;
     min-width: $controlMinWidth;
     transition:background-color .1s, color .1s;
 
-    &__label {
+    &Label {
       @include euiTextTruncate;
       max-width: 50%;
     }
 
-    &:not(.controlFrame--formControlLayout-clone) {
+    &:not(.controlFrame__formControlLayout-clone) {
       .controlFrame--dragHandle {
         cursor: grab;
       }
     }
 
-    .controlFrame--control {
+    .controlFrame__control {
       height: 100%;
       transition: opacity .1s;
 
@@ -93,21 +120,21 @@ $controlMinWidth: $euiSize * 14;
     }
   }
 
-  &-small {
+  &--small {
     width: $smallControl;
   }
 
-  &-medium {
+  &--medium {
     width: $mediumControl;
   }
 
-  &-large {
+  &--large {
     width: $largeControl;
   }
 
-  &-insertBefore,
-  &-insertAfter {
-    .controlFrame--formControlLayout:after {
+  &--insertBefore,
+  &--insertAfter {
+    .controlFrame__formControlLayout:after {
       content: '';
       position: absolute;
       background-color: transparentize($euiColorPrimary, .5);
@@ -118,14 +145,14 @@ $controlMinWidth: $euiSize * 14;
     }
   }
 
-  &-insertBefore {
-    .controlFrame--formControlLayout:after {
+  &--insertBefore {
+    .controlFrame__formControlLayout:after {
       left: -$euiSizeS;
     }
   }
 
-  &-insertAfter {
-    .controlFrame--formControlLayout:after {
+  &--insertAfter {
+    .controlFrame__formControlLayout:after {
       right: -$euiSizeS;
     }
   }
@@ -167,7 +194,7 @@ $controlMinWidth: $euiSize * 14;
     .euiFormRow__labelWrapper {
       opacity: 0;
     }
-    .controlFrame--formControlLayout {
+    .controlFrame__formControlLayout {
       background-color: $euiColorEmptyShade !important;
       color: transparent !important;
       box-shadow: none;
@@ -176,7 +203,7 @@ $controlMinWidth: $euiSize * 14;
         opacity: 0;
       }
 
-      .controlFrame--control {
+      .controlFrame__control {
         opacity: 0;
       }
     }

--- a/src/plugins/presentation_util/public/components/controls/control_group/editor/create_control.tsx
+++ b/src/plugins/presentation_util/public/components/controls/control_group/editor/create_control.tsx
@@ -112,8 +112,8 @@ export const CreateControlButton = () => {
   if (getInputControlTypes().length === 0) return null;
 
   const commonButtonProps = {
-    iconType: 'plus',
-    color: 'text' as EuiButtonIconColor,
+    iconType: 'plusInCircle',
+    color: 'primary' as EuiButtonIconColor,
     'data-test-subj': 'inputControlsSortingButton',
     'aria-label': ControlGroupStrings.management.getManageButtonTitle(),
   };

--- a/src/plugins/presentation_util/public/components/controls/control_group/editor/edit_control_group.tsx
+++ b/src/plugins/presentation_util/public/components/controls/control_group/editor/edit_control_group.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import {
   EuiTitle,
   EuiSpacer,
@@ -17,6 +17,7 @@ import {
   EuiButtonGroup,
   EuiButtonEmpty,
   EuiFlyoutHeader,
+  EuiCheckbox,
 } from '@elastic/eui';
 
 import {
@@ -44,6 +45,11 @@ export const EditControlGroup = () => {
 
   const dispatch = useEmbeddableDispatch();
   const { panels, controlStyle, defaultControlWidth } = useEmbeddableSelector((state) => state);
+  const [checked, setChecked] = useState(false);
+
+  const onChange = (e) => {
+    setChecked(e.target.checked);
+  };
 
   return (
     <>
@@ -66,34 +72,24 @@ export const EditControlGroup = () => {
         </EuiFormRow>
         <EuiSpacer size="m" />
         <EuiFormRow label={ControlGroupStrings.management.getDefaultWidthTitle()}>
-          <EuiFlexGroup direction={'row'}>
-            <EuiFlexItem>
-              <EuiButtonGroup
-                color="primary"
-                idSelected={defaultControlWidth ?? DEFAULT_CONTROL_WIDTH}
-                legend={ControlGroupStrings.management.controlWidth.getWidthSwitchLegend()}
-                options={CONTROL_WIDTH_OPTIONS}
-                onChange={(newWidth: string) =>
-                  dispatch(setDefaultControlWidth(newWidth as ControlWidth))
-                }
-              />
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiButtonEmpty
-                onClick={() =>
-                  dispatch(setAllControlWidths(defaultControlWidth ?? DEFAULT_CONTROL_WIDTH))
-                }
-                aria-label={'delete-all'}
-                iconType="returnKey"
-                size="s"
-              >
-                {ControlGroupStrings.management.getSetAllWidthsToDefaultTitle()}
-              </EuiButtonEmpty>
-            </EuiFlexItem>
-          </EuiFlexGroup>
+          <EuiButtonGroup
+            color="primary"
+            idSelected={defaultControlWidth ?? DEFAULT_CONTROL_WIDTH}
+            legend={ControlGroupStrings.management.controlWidth.getWidthSwitchLegend()}
+            options={CONTROL_WIDTH_OPTIONS}
+            onChange={(newWidth: string) =>
+              dispatch(setDefaultControlWidth(newWidth as ControlWidth))
+            }
+          />
         </EuiFormRow>
-
-        <EuiSpacer size="xl" />
+        <EuiSpacer size="s" />
+        <EuiCheckbox
+          id="widthsCheckbox"
+          label={ControlGroupStrings.management.getSetAllWidthsToDefaultTitle()}
+          checked={checked}
+          onChange={(e) => onChange(e)}
+        />
+        <EuiSpacer size="l" />
 
         <EuiButtonEmpty
           onClick={() => {

--- a/src/plugins/presentation_util/public/components/controls/control_group/opt_a.svg
+++ b/src/plugins/presentation_util/public/components/controls/control_group/opt_a.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="58" height="55" fill="none" viewBox="0 0 58 55">
+  <path fill="#3375C6" d="M0 55V0h58L0 55z"/>
+  <path fill="#F5C748" d="M0 11h58v6H0z"/>
+  <path fill="#EB95C4" d="M16 23h32v6H16z"/>
+</svg>


### PR DESCRIPTION
## Summary

- Added the empty state (re:graphic, @ryankeairns has already taken a sneak peek at this and we will for sure need to iterate on this before it is ready from a design perspective)

_**In this PR...**_
<img width="1024" alt="current" src="https://user-images.githubusercontent.com/4016496/137565260-230e310c-b7d9-437f-afaa-b05b77432c3b.png">

**_Other options explored..._**
<img width="1024" alt="opt_a" src="https://user-images.githubusercontent.com/4016496/137565256-e7151b6c-c514-4110-a6fe-702f23b12848.png">
<img width="1024" alt="opt_b" src="https://user-images.githubusercontent.com/4016496/137565259-c22f9fea-3ecc-4baf-bc35-33df080672f9.png">

- Cleaned up markup for the layout 
- Made changes to match EUI's naming conventions for CSS better, I believe there's still room for improvement here but prefer to get started with this now than later

@ThomThomson **pending:** hook the "set all widths to default" checkbox in the `Manage controls` flyout.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
