### PR TITLE
[Controls] Design for options list validation

### DIFF
--- a/src/plugins/controls/public/control_types/options_list/options_list.scss
+++ b/src/plugins/controls/public/control_types/options_list/options_list.scss
@@ -35,6 +35,10 @@
   font-weight: 300;
 }
 
+.optionsList__ignoredBadge {
+  margin-left: $euiSizeS;
+}
+
 .optionsList__selectionInvalid {
   text-decoration: line-through;
   color: $euiTextSubduedColor;

--- a/src/plugins/controls/public/control_types/options_list/options_list_popover_component.tsx
+++ b/src/plugins/controls/public/control_types/options_list/options_list_popover_component.tsx
@@ -46,7 +46,7 @@ export const OptionsListPopover = ({
   const {
     useEmbeddableSelector,
     useEmbeddableDispatch,
-    actions: { selectOption, deselectOption, deselectOptions, clearSelections, replaceSelection },
+    actions: { selectOption, deselectOption, clearSelections, replaceSelection },
   } = useReduxEmbeddableContext<OptionsListEmbeddableInput, typeof optionsListReducers>();
 
   const dispatch = useEmbeddableDispatch();
@@ -65,19 +65,6 @@ export const OptionsListPopover = ({
     <>
       <EuiPopoverTitle className="optionsList__popoverTitle" paddingSize="s">
         {title}
-        {invalidSelections && invalidSelections.length > 0 && (
-          <EuiToolTip content={OptionsListStrings.popover.getInvalidSelectionsTooltip()}>
-            <EuiBadge
-              color="warning"
-              iconType="cross"
-              iconSide="right"
-              iconOnClick={() => dispatch(deselectOptions(invalidSelections))}
-              iconOnClickAriaLabel={OptionsListStrings.popover.getInvalidSelectionsAriaLabel()}
-            >
-              {OptionsListStrings.popover.getInvalidSelectionsTitle(invalidSelections.length)}
-            </EuiBadge>
-          </EuiToolTip>
-        )}
       </EuiPopoverTitle>
       <div className="optionsList__actions">
         <EuiFormRow>
@@ -87,23 +74,37 @@ export const OptionsListPopover = ({
             alignItems="center"
             justifyContent="spaceBetween"
           >
-            {totalCardinality && (
-              <EuiFlexItem grow={false}>
-                <EuiToolTip
-                  content={OptionsListStrings.popover.getTotalCardinalityTooltip(totalCardinality)}
-                >
-                  <EuiBadge color="primary">{totalCardinality}</EuiBadge>
-                </EuiToolTip>
-              </EuiFlexItem>
-            )}
             <EuiFlexItem>
               <EuiFieldSearch
                 compressed
                 disabled={showOnlySelected}
                 onChange={(event) => updateSearchString(event.target.value)}
                 value={searchString}
+                placeholder={
+                  totalCardinality
+                    ? OptionsListStrings.popover.getTotalCardinalityPlaceholder(totalCardinality)
+                    : undefined
+                }
                 data-test-subj="optionsList-control-search-input"
               />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              {invalidSelections && invalidSelections.length > 0 && (
+                <EuiToolTip
+                  content={OptionsListStrings.popover.getInvalidSelectionsTooltip(
+                    invalidSelections.length
+                  )}
+                >
+                  <EuiBadge
+                    className="optionsList__ignoredBadge"
+                    color="warning"
+                    iconType="alert"
+                    iconSide="right"
+                  >
+                    {invalidSelections.length}
+                  </EuiBadge>
+                </EuiToolTip>
+              )}
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiToolTip

--- a/src/plugins/controls/public/control_types/options_list/options_list_strings.ts
+++ b/src/plugins/controls/public/control_types/options_list/options_list_strings.ts
@@ -71,6 +71,12 @@ export const OptionsListStrings = {
         defaultMessage: '{totalOptions} available options.',
         values: { totalOptions },
       }),
+    getTotalCardinalityPlaceholder: (totalOptions: number) =>
+      i18n.translate('controls.optionsList.popover.cardinalityPlaceholder', {
+        defaultMessage:
+          'Search {totalOptions} available {totalOptions, plural, one {option} other {options}}',
+        values: { totalOptions },
+      }),
     getInvalidSelectionsTitle: (invalidSelectionCount: number) =>
       i18n.translate('controls.optionsList.popover.invalidSelectionsTitle', {
         defaultMessage: '{invalidSelectionCount} selected options ignored',
@@ -80,10 +86,11 @@ export const OptionsListStrings = {
       i18n.translate('controls.optionsList.popover.invalidSelectionsAriaLabel', {
         defaultMessage: 'Deselect all ignored selections',
       }),
-    getInvalidSelectionsTooltip: () =>
+    getInvalidSelectionsTooltip: (selectedOptions: number) =>
       i18n.translate('controls.optionsList.popover.invalidSelectionsTooltip', {
         defaultMessage:
-          'One or more selected options are ignored because they are no longer in the data.',
+          '{selectedOptions} selected options are ignored because they are no longer in the data.',
+        values: { selectedOptions },
       }),
   },
   errors: {


### PR DESCRIPTION
## Summary

- Updates the location and style of the element that keeps track of how many options are being ignored.
- Updates the string we are using for the `ignored options` tooltip to handle 1 vs multiple options.
- Updates the placeholder in the search bar for options.

<img width="605" alt="image 14" src="https://user-images.githubusercontent.com/4016496/153103691-d7fa21d7-be63-4ea2-b41b-a2039ee8ff6b.png">

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
