### PR TITLE
Design clean up for control settings flyout

### DIFF
--- a/src/plugins/controls/public/control_group/editor/control_group_editor.tsx
+++ b/src/plugins/controls/public/control_group/editor/control_group_editor.tsx
@@ -169,9 +169,10 @@ export const ControlGroupEditor = ({
               />
             </>
           </EuiFormRow>
-          <EuiHorizontalRule />
+          <EuiHorizontalRule margin="m" />
           <EuiFlexGroup>
             <EuiFlexItem grow={false}>
+              <EuiSpacer size="xs" />
               <EuiSwitch
                 label={ControlGroupStrings.management.querySync.getQuerySettingsTitle()}
                 showLabel={false}
@@ -187,10 +188,10 @@ export const ControlGroupEditor = ({
               />
             </EuiFlexItem>
             <EuiFlexItem>
-              <EuiTitle size="xs">
+              <EuiTitle size="xxs">
                 <h3>{ControlGroupStrings.management.querySync.getQuerySettingsTitle()}</h3>
               </EuiTitle>
-              <EuiText>
+              <EuiText size="s">
                 <p>{ControlGroupStrings.management.querySync.getQuerySettingsSubtitle()}</p>
               </EuiText>
               <EuiSpacer size="s" />
@@ -200,35 +201,26 @@ export const ControlGroupEditor = ({
                 buttonContent={ControlGroupStrings.management.querySync.getAdvancedSettingsTitle()}
               >
                 <EuiSpacer size="s" />
-                <EuiFormRow
-                  label={ControlGroupStrings.management.querySync.getIgnoreTimerangeTitle()}
-                  display="columnCompressedSwitch"
-                >
+                <EuiFormRow hasChildLabel display="columnCompressedSwitch">
                   <EuiSwitch
                     label={ControlGroupStrings.management.querySync.getIgnoreTimerangeTitle()}
-                    showLabel={false}
+                    compressed
                     checked={Boolean(controlGroupEditorState.ignoreParentSettings?.ignoreTimerange)}
                     onChange={(e) => updateIgnoreSetting({ ignoreTimerange: e.target.checked })}
                   />
                 </EuiFormRow>
-                <EuiFormRow
-                  label={ControlGroupStrings.management.querySync.getIgnoreQueryTitle()}
-                  display="columnCompressedSwitch"
-                >
+                <EuiFormRow hasChildLabel display="columnCompressedSwitch">
                   <EuiSwitch
                     label={ControlGroupStrings.management.querySync.getIgnoreQueryTitle()}
-                    showLabel={false}
+                    compressed
                     checked={Boolean(controlGroupEditorState.ignoreParentSettings?.ignoreQuery)}
                     onChange={(e) => updateIgnoreSetting({ ignoreQuery: e.target.checked })}
                   />
                 </EuiFormRow>
-                <EuiFormRow
-                  label={ControlGroupStrings.management.querySync.getIgnoreFilterPillsTitle()}
-                  display="columnCompressedSwitch"
-                >
+                <EuiFormRow hasChildLabel display="columnCompressedSwitch">
                   <EuiSwitch
                     label={ControlGroupStrings.management.querySync.getIgnoreFilterPillsTitle()}
-                    showLabel={false}
+                    compressed
                     checked={Boolean(controlGroupEditorState.ignoreParentSettings?.ignoreFilters)}
                     onChange={(e) => updateIgnoreSetting({ ignoreFilters: e.target.checked })}
                   />
@@ -236,9 +228,10 @@ export const ControlGroupEditor = ({
               </EuiAccordion>
             </EuiFlexItem>
           </EuiFlexGroup>
-          <EuiHorizontalRule />
+          <EuiHorizontalRule margin="m" />
           <EuiFlexGroup>
             <EuiFlexItem grow={false}>
+              <EuiSpacer size="xs" />
               <EuiSwitch
                 label={ControlGroupStrings.management.validateSelections.getValidateSelectionsTitle()}
                 showLabel={false}
@@ -247,21 +240,22 @@ export const ControlGroupEditor = ({
               />
             </EuiFlexItem>
             <EuiFlexItem>
-              <EuiTitle size="xs">
+              <EuiTitle size="xxs">
                 <h3>
                   {ControlGroupStrings.management.validateSelections.getValidateSelectionsTitle()}
                 </h3>
               </EuiTitle>
-              <EuiText>
+              <EuiText size="s">
                 <p>
                   {ControlGroupStrings.management.validateSelections.getValidateSelectionsSubTitle()}
                 </p>
               </EuiText>
             </EuiFlexItem>
           </EuiFlexGroup>
-          <EuiHorizontalRule />
+          <EuiHorizontalRule margin="m" />
           <EuiFlexGroup>
             <EuiFlexItem grow={false}>
+              <EuiSpacer size="xs" />
               <EuiSwitch
                 label={ControlGroupStrings.management.controlChaining.getHierarchyTitle()}
                 showLabel={false}
@@ -274,16 +268,16 @@ export const ControlGroupEditor = ({
               />
             </EuiFlexItem>
             <EuiFlexItem>
-              <EuiTitle size="xs">
+              <EuiTitle size="xxs">
                 <h3>{ControlGroupStrings.management.controlChaining.getHierarchyTitle()}</h3>
               </EuiTitle>
-              <EuiText>
+              <EuiText size="s">
                 <p>{ControlGroupStrings.management.controlChaining.getHierarchySubTitle()}</p>
               </EuiText>
             </EuiFlexItem>
           </EuiFlexGroup>
-          <EuiHorizontalRule />
-          <EuiSpacer size="l" />
+          <EuiHorizontalRule margin="m" />
+          <EuiSpacer size="m" />
           <EuiButtonEmpty
             onClick={onDeleteAll}
             aria-label={'delete-all'}


### PR DESCRIPTION
## Summary

Sending some design adjustments to the flyout

<img width="1079" alt="image" src="https://user-images.githubusercontent.com/4016496/159343537-6dd9bc21-8a14-4bc6-96f7-5b67d49007b5.png">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
