### PR TITLE
[Controls] Improve fatal error message styling

### DIFF
--- a/src/plugins/embeddable/public/lib/embeddables/error_embedabble.scss
+++ b/src/plugins/embeddable/public/lib/embeddables/error_embedabble.scss
@@ -1,0 +1,10 @@
+.errorEmbeddable__popoverAnchor {
+  max-width: 100%;
+}
+
+.errorEmbeddable__button {
+  padding-left: 0 !important;
+  .euiIcon {
+    margin-right: $euiSizeXS * .5;
+  }
+}

--- a/src/plugins/embeddable/public/lib/embeddables/error_embeddable.tsx
+++ b/src/plugins/embeddable/public/lib/embeddables/error_embeddable.tsx
@@ -6,15 +6,7 @@
  * Side Public License, v 1.
  */
 
-import {
-  EuiText,
-  EuiIcon,
-  EuiSpacer,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiPopover,
-  EuiLink,
-} from '@elastic/eui';
+import { EuiText, EuiIcon, EuiSpacer, EuiPopover, EuiLink } from '@elastic/eui';
 import React, { useState } from 'react';
 import ReactDOM from 'react-dom';
 import { KibanaThemeProvider, Markdown } from '@kbn/kibana-react-plugin/public';
@@ -23,6 +15,7 @@ import { Embeddable } from './embeddable';
 import { EmbeddableInput, EmbeddableOutput, IEmbeddable } from './i_embeddable';
 import { IContainer } from '../containers';
 import { getTheme } from '../../services';
+import './error_embedabble.scss';
 
 export const ERROR_EMBEDDABLE_TYPE = 'error';
 
@@ -94,41 +87,28 @@ const CompactEmbeddableError = ({ children }: { children?: React.ReactNode }) =>
   const [isPopoverOpen, setPopoverOpen] = useState(false);
 
   const popoverButton = (
-    <EuiLink onClick={() => setPopoverOpen((open) => !open)}>
-      {i18n.translate('embeddableApi.panel.errorEmbeddable.learnMore', {
-        defaultMessage: 'Learn more.',
-      })}
-    </EuiLink>
+    <EuiText className="errorEmbeddable__button" size="xs">
+      <EuiLink
+        className="eui-textTruncate"
+        color="subdued"
+        onClick={() => setPopoverOpen((open) => !open)}
+      >
+        <EuiIcon type="alert" color="danger" />
+        {i18n.translate('embeddableApi.panel.errorEmbeddable.learnMore', {
+          defaultMessage: 'A fatal error has occurred. Learn more.',
+        })}
+      </EuiLink>
+    </EuiText>
   );
 
   return (
-    <EuiFlexGroup
-      style={{ height: '100%', whiteSpace: 'nowrap' }}
-      gutterSize="none"
-      alignItems="center"
-      justifyContent="center"
+    <EuiPopover
+      button={popoverButton}
+      isOpen={isPopoverOpen}
+      anchorClassName="errorEmbeddable__popoverAnchor"
+      closePopover={() => setPopoverOpen(false)}
     >
-      <EuiFlexItem grow={false}>
-        <EuiIcon type="alert" color="danger" />
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <EuiText>
-          <p>
-            {i18n.translate('embeddableApi.panel.errorEmbeddable.errorText', {
-              defaultMessage: 'A fatal error has occurred.',
-            })}
-          </p>
-        </EuiText>
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiPopover
-          button={popoverButton}
-          isOpen={isPopoverOpen}
-          closePopover={() => setPopoverOpen(false)}
-        >
-          {children}
-        </EuiPopover>
-      </EuiFlexItem>
-    </EuiFlexGroup>
+      {children}
+    </EuiPopover>
   );
 };


### PR DESCRIPTION
## Summary

Sending some suggestions to improve the design for controls' fatal error.

- Given that in sizes other than large the message won't display in its entirety I think it's better to make the whole text clickable (i.e. the trigger of the popover containing the details). 
- I reduced the font size so that it is better aligned with the other font sizes in the controls. 
- Turned the link into subdued color.
- Removed FlexGroup and FlexItem. Sometimes these elements bring unnecessary complexity to the markup, particularly when we have a very simple layout.
- Added truncation/

<img width="999" alt="image" src="https://user-images.githubusercontent.com/4016496/172682248-4b362c3e-1f1f-4200-b922-0825a65b98be.png">

<img width="999" alt="image" src="https://user-images.githubusercontent.com/4016496/172682329-2c26f6fa-0f8f-4212-9539-06a7e6a2bde0.png">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
